### PR TITLE
fix: not using consistent string for no data, causing alarms to not properly resolve

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.bigboxer23</groupId>
   <artifactId>solar-moon-common</artifactId>
-  <version>1.10.9</version>
+  <version>1.10.10</version>
   <packaging>jar</packaging>
   <name>solar-moon-common</name>
   <url>https://github.com/bigboxer23/solar-moon-common</url>

--- a/src/main/java/com/bigboxer23/solar_moon/alarm/AlarmComponent.java
+++ b/src/main/java/com/bigboxer23/solar_moon/alarm/AlarmComponent.java
@@ -399,7 +399,7 @@ public class AlarmComponent extends AbstractDynamodbComponent<Alarm> implements 
 					data.getCustomerId(),
 					data.getDeviceId(),
 					data.getSiteId(),
-					"No data recently from device.  Last data: "
+					NO_DATA_RECENTLY
 							+ data.getDate().getTime());
 		}
 		// Inspect device, weather, site data


### PR DESCRIPTION
fix: not using consistent string for no data, causing alarms to not properly resolve